### PR TITLE
Fix Mapbox token configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A small demo showing an itinerary map using React, Vite and TypeScript.
 
+Create a `.env` file with your Mapbox access token:
+
+```bash
+echo "VITE_MAPBOX_TOKEN=pk.your_token_here" > .env
+```
+
 ## Scripts
 
 ```bash

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -3,7 +3,10 @@ import mapboxgl from 'mapbox-gl';
 import { Stop } from '../types';
 import { UI } from '../ui';
 
-mapboxgl.accessToken = 'pk.INSERT_TOKEN';
+// Use a Vite environment variable so the API token can be provided at build time
+// without committing secrets to the repository.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+mapboxgl.accessToken = (import.meta as any).env.VITE_MAPBOX_TOKEN || '';
 
 type Props = {
   stops: Stop[];


### PR DESCRIPTION
## Summary
- load Mapbox token from Vite env variable
- document the env variable in the README

## Testing
- `npm test --silent` *(fails: vitest not found)*