### PR TITLE
Fix layout gaps and unify card padding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,37 +10,22 @@ export default function App() {
   const [open, setOpen] = useState(true);
   const [activeId, setActiveId] = useState<number | null>(null);
   return (
-  <div className="w-screen h-screen relative">
-    {/* clickable header that jumps to the Berlin stop */}
-    <button
-      type="button"
-      className="absolute top-0 left-0 right-0 bg-blue-500 text-white text-center py-2 cursor-pointer z-10"
-      onClick={() => setActiveId(1)}
-    >
-      Day&nbsp;1-2 : fly to Berlin
-    </button>
+    <div className="container w-screen h-screen relative">
+      {/* clickable header that jumps to the Berlin stop */}
+      <button
+        type="button"
+        className="absolute top-0 left-0 right-0 bg-blue-500 text-white text-center py-2 cursor-pointer z-10"
+        onClick={() => setActiveId(1)}
+      >
+        Day&nbsp;1-2 : fly to Berlin
+      </button>
 
-    <MapView
-      stops={stops}
-      activeId={activeId}
-      onMarkerClick={id => setActiveId(id)}
-    />
-
-    {open && (
-      <ItineraryBottomSheet
-        stops={stops}
-        activeId={activeId}
-        onSelect={id => setActiveId(id)}
-        onClose={() => setOpen(false)}
-      />
-    )}
-  </div>
-);
       <MapView
         stops={stops}
         activeId={activeId}
         onMarkerClick={id => setActiveId(id)}
       />
+
       {open && (
         <ItineraryBottomSheet
           stops={stops}

--- a/src/components/ItineraryBottomSheet.tsx
+++ b/src/components/ItineraryBottomSheet.tsx
@@ -32,16 +32,16 @@ export default function ItineraryBottomSheet({
       transition={{ type: 'spring', duration: 0.04 }}
       className="fixed bottom-0 left-1/2 -translate-x-1/2 bg-white shadow-md rounded-sheet"
     >
-      <div className="flex justify-between items-center p-4">
+      <div className="card flex justify-between items-center">
         <h2 className="text-2xl font-semibold">Itinerary</h2>
         <button onClick={onClose} className="text-xl">×</button>
       </div>
       <img src="/alps.jpg" alt="Alps" className="w-full aspect-video object-cover rounded-t-sheet" />
-      <div className="p-4">
+      <div className="card">
         <h3 className="text-lg font-bold">Swiss Alps</h3>
         <p className="text-sm text-gray-600">4 days</p>
       </div>
-      <ul className="px-4 pb-4 space-y-2">
+      <ul className="px-4 pb-4 space-y-2 pl-2">
         {stops.map((stop, i) => (
           <li
             key={stop.id}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .card {
+    @apply p-4 md:p-5;
+  }
+}
+
+@media (min-height: 700px) {
+  .container {
+    @apply pt-2;
+  }
+}


### PR DESCRIPTION
## Summary
- relax container for tall screens
- unify card padding via new `.card` utility
- pad itinerary list for breathing room
- fix duplicated code in `App` and apply container class

## Testing
- `npm test` *(fails: vitest not found)*