### PR TITLE
Add sticky day headers and unify card shadows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,31 +9,23 @@ const stops: Stop[] = stopsData as Stop[];
 export default function App() {
   const [open, setOpen] = useState(true);
   const [activeId, setActiveId] = useState<number | null>(null);
+
   return (
+    <div className="w-screen h-screen relative">
+      {/* clickable header that jumps to the Berlin stop */}
+      <button
+        type="button"
+        className="absolute top-0 left-0 right-0 bg-primary text-white text-center py-2 cursor-pointer z-10"
+        onClick={() => setActiveId(1)}
+      >
+        Day&nbsp;1-2 : fly to Berlin
+      </button>
 
-  <div className="w-screen h-screen relative">
-    {/* clickable header that jumps to the Berlin stop */}
-    <button
-      type="button"
-      className="absolute top-0 left-0 right-0 bg-primary text-white text-center py-2 cursor-pointer z-10"
-      onClick={() => setActiveId(1)}
-    >
-      Day&nbsp;1-2 : fly to Berlin
-    </button>
-
-
-
-
-
-);
-
-      
-        
-  <MapView
-    stops={stops}
-    activeId={activeId}
-    onMarkerClick={(id) => setActiveId(id)}
-  />
+      <MapView
+        stops={stops}
+        activeId={activeId}
+        onMarkerClick={id => setActiveId(id)}
+      />
 
       {open && (
         <ItineraryBottomSheet
@@ -43,11 +35,6 @@ export default function App() {
           onClose={() => setOpen(false)}
         />
       )}
-
-      />
-    )}
-
     </div>
   );
-
 }

--- a/src/components/DayHeader.tsx
+++ b/src/components/DayHeader.tsx
@@ -1,0 +1,32 @@
+import dayjs from 'dayjs';
+import { useEffect, useRef, useState } from 'react';
+
+export default function DayHeader({ date }: { date: string }) {
+  const ref = useRef<HTMLHeadingElement>(null);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setVisible(entry.intersectionRatio === 1);
+      },
+      { threshold: 1 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <h3
+      ref={ref}
+      className={
+        'sticky top-0 z-20 bg-gradient-to-r from-blue-500 to-sky-500 text-white font-semibold flex items-center justify-center transition-opacity h-12 ' +
+        (visible ? 'opacity-100' : 'opacity-0')
+      }
+    >
+      {dayjs(date).format('MMM D, ddd')}
+    </h3>
+  );
+}

--- a/src/components/ForecastGrid.tsx
+++ b/src/components/ForecastGrid.tsx
@@ -16,7 +16,7 @@ export default function ForecastGrid({ forecast }: Props) {
       {forecast.map(f => (
         <div
           key={f.day}
-          className="rounded-xl shadow-inner bg-white p-2 text-center text-sm"
+          className="rounded-xl shadow bg-white p-2 text-center text-sm"
         >
           <div className="font-semibold mb-1">{f.day}</div>
           <div className="flex items-center justify-center gap-1 text-gray-700">

--- a/src/components/ItineraryBottomSheet.tsx
+++ b/src/components/ItineraryBottomSheet.tsx
@@ -5,6 +5,7 @@ import { UI } from '../ui';
 import TravelCard from './TravelCard';
 import ForecastGrid, { DayForecast } from './ForecastGrid';
 import LiveMapButton from './LiveMapButton';
+import DayHeader from './DayHeader';
 
 type Props = {
   stops: Stop[];
@@ -39,40 +40,38 @@ export default function ItineraryBottomSheet({
       transition={{ type: 'spring', duration: 0.04 }}
       className="fixed bottom-0 left-1/2 -translate-x-1/2 bg-white shadow-md rounded-sheet"
     >
-
-
-     
-          <div className="flex justify-between items-center p-4">
-    <h2 className="text-2xl font-semibold tracking-tight">Itinerary</h2>
-    <button onClick={onClose} className="text-xl">x</button>
-  </div>
-<img src="/alps.jpg" alt="Alps" className="w-full aspect-video object-cover rounded-t-sheet" />
-      <div className="card">
-        <h3 className="text-lg font-bold">Swiss Alps</h3>
-        <p className="text-sm text-gray-600">4 days</p>
-
-
+      <div className="flex justify-between items-center p-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Itinerary</h2>
+        <button onClick={onClose} className="text-xl">x</button>
       </div>
-      <img src="/alps.jpg" alt="Alps" className="w-full aspect-video object-cover rounded-t-sheet" />
-        <div className="p-4">
-          <h3 className="text-base font-bold">Swiss Alps</h3>
-          <p className="text-sm text-gray-600">4 days</p>
-
-      </div>
-      <ul className="px-4 pb-4 space-y-2 pl-2">
-        {stops.map((stop, i) => (
-          <TravelCard
-            key={stop.id}
-
-            stop={stop}
-            index={i}
-            active={stop.id === activeId}
-            last={i === stops.length - 1}
-            onSelect={onSelect}
-          />
-
-        ))}
-      </ul>
+      {(() => {
+        const days: { date: string; stops: Stop[] }[] = [];
+        stops.forEach(s => {
+          const last = days[days.length - 1];
+          if (!last || last.date !== s.date) {
+            days.push({ date: s.date, stops: [s] });
+          } else {
+            last.stops.push(s);
+          }
+        });
+        return days.map(day => (
+          <div key={day.date} className="mb-4">
+            <DayHeader date={day.date} />
+            <ul className="px-4 pb-4 space-y-2 pl-2">
+              {day.stops.map((stop, i) => (
+                <TravelCard
+                  key={stop.id}
+                  stop={stop}
+                  index={i}
+                  active={stop.id === activeId}
+                  last={i === day.stops.length - 1}
+                  onSelect={onSelect}
+                />
+              ))}
+            </ul>
+          </div>
+        ));
+      })()}
       <ForecastGrid forecast={forecast} />
       <div className="px-4 pb-4">
         <LiveMapButton onClick={onClose}>Live Map</LiveMapButton>

--- a/src/components/TravelCard.tsx
+++ b/src/components/TravelCard.tsx
@@ -16,7 +16,7 @@ export default function TravelCard({ stop, index, active, last, onSelect }: Trav
     <li
       onClick={() => onSelect(stop.id)}
       className={
-        `relative pl-3 pr-2 py-2 flex items-start gap-2 cursor-pointer before:content-[''] before:absolute before:left-0 before:top-0 before:w-1 before:h-full before:rounded-r ` +
+        `relative pl-3 pr-2 py-2 flex items-start gap-2 cursor-pointer before:content-[''] before:absolute before:left-0 before:top-0 before:w-1 before:h-full before:rounded-r rounded-lg bg-white shadow-lg shadow-slate-900/30 ` +
         (active ? 'before:bg-blue-500 bg-blue-50' : 'before:bg-gray-200')
       }
     >


### PR DESCRIPTION
## Summary
- add a `DayHeader` component with a sticky gradient bar
- group stops by day and render headers in `ItineraryBottomSheet`
- apply consistent shadows to interactive cards and info tiles
- clean up `App.tsx`

## Testing
- `npm test` *(fails: vitest not found)*