### PR TITLE
Unify icon set

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,31 +9,23 @@ const stops: Stop[] = stopsData as Stop[];
 export default function App() {
   const [open, setOpen] = useState(true);
   const [activeId, setActiveId] = useState<number | null>(null);
+
   return (
+    <div className="w-screen h-screen relative">
+      {/* clickable header that jumps to the Berlin stop */}
+      <button
+        type="button"
+        className="absolute top-0 left-0 right-0 bg-primary text-white text-center py-2 cursor-pointer z-10"
+        onClick={() => setActiveId(1)}
+      >
+        Day&nbsp;1-2 : fly to Berlin
+      </button>
 
-  <div className="w-screen h-screen relative">
-    {/* clickable header that jumps to the Berlin stop */}
-    <button
-      type="button"
-      className="absolute top-0 left-0 right-0 bg-primary text-white text-center py-2 cursor-pointer z-10"
-      onClick={() => setActiveId(1)}
-    >
-      Day&nbsp;1-2 : fly to Berlin
-    </button>
-
-
-
-
-
-);
-
-      
-        
-  <MapView
-    stops={stops}
-    activeId={activeId}
-    onMarkerClick={(id) => setActiveId(id)}
-  />
+      <MapView
+        stops={stops}
+        activeId={activeId}
+        onMarkerClick={id => setActiveId(id)}
+      />
 
       {open && (
         <ItineraryBottomSheet
@@ -43,11 +35,6 @@ export default function App() {
           onClose={() => setOpen(false)}
         />
       )}
-
-      />
-    )}
-
     </div>
   );
-
 }

--- a/src/components/ForecastGrid.tsx
+++ b/src/components/ForecastGrid.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { IconProps } from '../icons';
 
 export type DayForecast = {
   day: string;
   condition: string;
-  icon: string;
+  Icon: React.ComponentType<IconProps>;
 };
 
 type Props = {
@@ -21,7 +22,7 @@ export default function ForecastGrid({ forecast }: Props) {
           <div className="font-semibold mb-1">{f.day}</div>
           <div className="flex items-center justify-center gap-1 text-gray-700">
             <span className="text-base" aria-hidden="true">
-              {f.icon}
+              <f.Icon className="w-6 h-6" />
             </span>
             <span>{f.condition}</span>
           </div>

--- a/src/components/GoogleMapsLink.tsx
+++ b/src/components/GoogleMapsLink.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ExternalLinkIcon } from '../icons';
 
 export type GoogleMapsLinkProps = {
   coords: [number, number];
@@ -17,24 +18,5 @@ export default function GoogleMapsLink({ coords, className }: GoogleMapsLinkProp
       <span className="sr-only">Open in Google Maps</span>
       <ExternalLinkIcon className="w-4 h-4" />
     </a>
-  );
-}
-
-function ExternalLinkIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M18 3h3v3" />
-      <path d="M11 13l9-9" />
-      <path d="M5 7v11a1 1 0 0 0 1 1h11" />
-    </svg>
   );
 }

--- a/src/components/ItineraryBottomSheet.tsx
+++ b/src/components/ItineraryBottomSheet.tsx
@@ -5,6 +5,7 @@ import { UI } from '../ui';
 import TravelCard from './TravelCard';
 import ForecastGrid, { DayForecast } from './ForecastGrid';
 import LiveMapButton from './LiveMapButton';
+import { CloudRainIcon, SunIcon, CloudIcon, XIcon } from '../icons';
 
 type Props = {
   stops: Stop[];
@@ -24,9 +25,9 @@ export default function ItineraryBottomSheet({
   const dragConstraints = { top: -400, bottom: 0 };
   const ref = useRef<HTMLDivElement>(null);
   const forecast: DayForecast[] = [
-    { day: 'Mon', condition: 'Rain', icon: '☔️' },
-    { day: 'Tue', condition: 'Sunny', icon: '☀️' },
-    { day: 'Wed', condition: 'Cloudy', icon: '☁️' }
+    { day: 'Mon', condition: 'Rain', Icon: CloudRainIcon },
+    { day: 'Tue', condition: 'Sunny', Icon: SunIcon },
+    { day: 'Wed', condition: 'Cloudy', Icon: CloudIcon }
   ];
 
   return (
@@ -44,7 +45,9 @@ export default function ItineraryBottomSheet({
      
           <div className="flex justify-between items-center p-4">
     <h2 className="text-2xl font-semibold tracking-tight">Itinerary</h2>
-    <button onClick={onClose} className="text-xl">x</button>
+    <button onClick={onClose} className="text-xl">
+      <XIcon className="w-6 h-6" />
+    </button>
   </div>
 <img src="/alps.jpg" alt="Alps" className="w-full aspect-video object-cover rounded-t-sheet" />
       <div className="card">

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+export type IconProps = React.SVGProps<SVGSVGElement>;
+
+export function SunIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  );
+}
+
+export function CloudIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M17 18H7a4 4 0 1 1 0-8 5 5 0 0 1 9.9 1A4 4 0 1 1 17 18z" />
+    </svg>
+  );
+}
+
+export function CloudRainIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M17 17H7a4 4 0 1 1 0-8 5 5 0 0 1 9.9 1A4 4 0 1 1 17 17z" />
+      <path d="M8 20v.01M12 20v.01M16 20v.01" />
+    </svg>
+  );
+}
+
+export function XIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M6 6l12 12M6 18L18 6" />
+    </svg>
+  );
+}
+
+export function ExternalLinkIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M18 3h3v3" />
+      <path d="M11 13l9-9" />
+      <path d="M5 7v11a1 1 0 0 0 1 1h11" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add central icon library with Lucide-style icons
- use outline icons in forecast and bottom sheet
- remove emoji icons for weather conditions
- fix corrupted App.tsx file

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm test` *(fails: vitest: not found)*